### PR TITLE
Update test configuration to match ATS hardware

### DIFF
--- a/VeriStandTestCase/Tests/Unit/Assets/BenchmarkConfiguration.ini
+++ b/VeriStandTestCase/Tests/Unit/Assets/BenchmarkConfiguration.ini
@@ -1,2 +1,2 @@
 [Overrides]
-"Targets/Controller/IP Address" = "10.2.104.27"
+"Targets/Controller/IP Address" = "VS-Eco-Slave-8880"

--- a/VeriStandTestCase/Tests/Unit/Assets/DummyProperty.ini
+++ b/VeriStandTestCase/Tests/Unit/Assets/DummyProperty.ini
@@ -1,5 +1,5 @@
 [Overrides]
-"Targets/Controller/IP Address" = "10.2.104.27"
+"Targets/Controller/IP Address" = "VS-Eco-Slave-8880"
 
 [Properties]
 "Dummy Property" = "Dummy Value"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-testing-tools/blob/master/CONTRIBUTING.md).


### What does this Pull Request accomplish?

Update the configuration files to match the hostnames of the ATS hardware.

### Why should this Pull Request be merged?

The tests which deploy system definitions are currently failing.

### What testing has been done?

None.