### PR TITLE
Change access scope to 'Public' for SaveSystemDefinitionFile VI

### DIFF
--- a/VeriStandTestUtilities/VeriStandTestUtilities.lvlib
+++ b/VeriStandTestUtilities/VeriStandTestUtilities.lvlib
@@ -134,9 +134,7 @@
 	<Item Name="ReadTDMSFileFromDataLogConfiguration.vi" Type="VI" URL="../../VeriStandTestCase/Utilities/ReadTDMSFileFromDataLogConfiguration.vi">
 		<Property Name="NI.LibItem.Scope" Type="Int">2</Property>
 	</Item>
-	<Item Name="SaveSystemDefinitionFile.vi" Type="VI" URL="../SaveSystemDefinitionFile.vi">
-		<Property Name="NI.LibItem.Scope" Type="Int">2</Property>
-	</Item>
+	<Item Name="SaveSystemDefinitionFile.vi" Type="VI" URL="../SaveSystemDefinitionFile.vi"/>
 	<Item Name="SystemDefinitionInformation.ctl" Type="VI" URL="../SystemDefinitionInformation.ctl"/>
 	<Item Name="SystemDefinitionPropertyType.ctl" Type="VI" URL="../SystemDefinitionPropertyType.ctl">
 		<Property Name="NI.LibItem.Scope" Type="Int">2</Property>


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-testing-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Make the library-defined access scope Public for SaveSystemDefinitionFile.vi

### Why should this Pull Request be merged?

Public scope allows this subVI to be used directly in automated unit and system tests for custom devices.

### What testing has been done?

Added VI to a system test and verified that scripted system definition was saved.
