### PR TITLE
Diff in LabVIEW 2019

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-diffPipeline('2017')
+diffPipeline('2019')


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-testing-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Diff this VI using LabVIEW 2019, since our build agents no longer support LabVIEW 2017.

### Why should this Pull Request be merged?

PR builds are currently stuck waiting for agents.

### What testing has been done?

N/A
