### PR TITLE
Build for VeriStand 2024, bump version to 24.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,8 @@ stages:
           bitness: '64bit'
         - version: '2023'
           bitness: '64bit'
+        - version: '2024'
+          bitness: '64bit'
 
       buildSteps:
         - projectLocation: 'VeriStand Test Utilities.lvproj'
@@ -30,7 +32,7 @@ stages:
           target: 'My Computer'
           buildSpec: 'SourceDistribution'
 
-      releaseVersion: '23.5.0'
+      releaseVersion: '24.0.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\testing_tools'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-testing-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Build for VeriStand 2024, and bump the repo version to 24.0.

This does not drop 2020 as the testing tools may need to support it for a bit longer due to internal use.

### Why should this Pull Request be merged?

Needed to validate the 2024 custom device builds.

### What testing has been done?

PR build.
