### PR TITLE
add lv2026, remove 2023, bump to 26.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The source for this repository is written in [LabVIEW 2020](http://www.ni.com/en
 
 The following top-level dependencies are required to build and use the repository:
 
-- [NI VeriStand](http://www.ni.com/veristand/) >= 2023
+- [NI VeriStand](http://www.ni.com/veristand/) >= 2024
 - [LabVIEW Command Line Interface](http://www.ni.com/en-us/support/downloads/software-products/download.ni-labview-command-line-interface.html)
 - [JKI VI Tester](vipm://jki_labs_tool_vi_tester?repo_url=http://www.jkisoft.com/packages) >= 3.0.2.294-1
 - [VI Tester JUnit XML Test Results](vipm://jki_lib_vi_tester_junit_xml_results?repo_url=http://www.jkisoft.com/packages) >= 2.0.1.16

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,11 +17,11 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild:
-        - version: '2023'
-          bitness: '64bit'
         - version: '2024'
           bitness: '64bit'
         - version: '2025'
+          bitness: '64bit'
+        - version: '2026'
           bitness: '64bit'
 
       buildSteps:
@@ -30,7 +30,7 @@ stages:
           target: 'My Computer'
           buildSpec: 'SourceDistribution'
 
-      releaseVersion: '25.0.0'
+      releaseVersion: '26.0.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\testing_tools'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-testing-tools/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-testing-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add new LV, drop unsupported. Bump release version.

### Why should this Pull Request be merged?

Required for future release

### What testing has been done?

PR build
